### PR TITLE
Dictionary match with Caesar shift

### DIFF
--- a/init.coffee
+++ b/init.coffee
@@ -8,7 +8,7 @@ DICTIONARY_MATCHERS = [
 ]
 
 MATCHERS = DICTIONARY_MATCHERS.concat [
-  l33t_match,
+  caesar_match, l33t_match,
   digits_match, year_match, date_match,
   repeat_match, sequence_match,
   spatial_match

--- a/matching.coffee
+++ b/matching.coffee
@@ -52,6 +52,33 @@ build_dict_matcher = (dict_name, ranked_dict) ->
     matches
 
 #-------------------------------------------------------------------------------
+# dictionary match with caesar shift -------------------------------------------
+#-------------------------------------------------------------------------------
+
+caesar_variants = (password) ->
+  variants = []
+  shift = (chr) ->
+    if chr.match /[a-z]/
+      chr = String.fromCharCode 97 + (chr.charCodeAt(0) - 97 + n) % 26
+    chr
+  for n in [1..25]
+    variants.push (password.split('').map shift).join ''
+  variants
+
+caesar_match = (password) ->
+  matches = []
+  for variant in caesar_variants password.toLowerCase()
+    for matcher in DICTIONARY_MATCHERS
+      for match in matcher(variant)
+        token = password[match.i..match.j]
+        if token.toLowerCase() == match.matched_word
+          continue
+        match.caesar = true
+        match.token = token
+        matches.push match
+  matches
+
+#-------------------------------------------------------------------------------
 # dictionary match with common l33t substitutions ------------------------------
 #-------------------------------------------------------------------------------
 

--- a/scoring.coffee
+++ b/scoring.coffee
@@ -192,8 +192,10 @@ spatial_entropy = (match) ->
 dictionary_entropy = (match) ->
   match.base_entropy = lg match.rank # keep these as properties for display purposes
   match.uppercase_entropy = extra_uppercase_entropy match
+  match.caesar_entropy = extra_caesar_entropy match
   match.l33t_entropy = extra_l33t_entropy match
-  match.base_entropy + match.uppercase_entropy + match.l33t_entropy
+  match.base_entropy + match.uppercase_entropy + match.caesar_entropy +
+    match.l33t_entropy
 
 START_UPPER = /^[A-Z][^A-Z]+$/
 END_UPPER = /^[^A-Z]+[A-Z]$/
@@ -215,6 +217,8 @@ extra_uppercase_entropy = (match) ->
   possibilities = 0
   possibilities += nCk(U + L, i) for i in [0..Math.min(U, L)]
   lg possibilities
+
+extra_caesar_entropy = (match) -> if match.caesar then lg 26 else 0
 
 extra_l33t_entropy = (match) ->
   return 0 if not match.l33t


### PR DESCRIPTION
Entropy for 'correct horse battery' (no staple) is 43.197. If
you simply shift the letters by 3 places, you get a somewhat
memorable 'fruuhfw kruvh edwwhub'. The program tells you this is
a very strong password, with entropy at ~111 bits. This is
obviously wrong. Any decent password cracker will try the
Caesar shift.

This patch addresses the issue by introducing a Caesar shift
matcher.